### PR TITLE
Bump ethereumjs-util for windows support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "ethereum-common": "0.0.16",
-    "ethereumjs-util": "^4.0.0"
+    "ethereumjs-util": "^4.0.1"
   },
   "devDependencies": {
     "async": "^1.4.2",


### PR DESCRIPTION
Note: Install has this warning:

```
UNMET PEER DEPENDENCY watchify@>=3 <4
```

I have no idea if it matters, but it exists on both Windows and Mac on install.