### PR TITLE
Polyfill Object.assign (again)

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,16 @@ Transaction.prototype.verifySignature = function () {
 Transaction.prototype.sign = function (privateKey) {
   var msgHash = this.hash(false)
   var sig = ethUtil.ecsign(msgHash, privateKey)
-  Object.assign(this, sig)
+  if (Object.assign) {
+    Object.assign(this, sig)
+
+  } else {
+    for (var property in sig) {
+      if (sig.hasOwnProperty(property)) {
+        this[property] = sig[property];
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Node.js does not have an `Object.assign`, which is used for transaction signing.

If you decided to include this pull request, I am curious whether the call in dist/ethereumjs-tx.js should also be fixed manually? I ran `npm build`, but it did not update the dist build.

Thanks,
RicMoo