### PR TITLE
Update ethereumjs-util version to v4.5.0 to avoid Meteor errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "ethereum-common": "^0.0.17",
-    "ethereumjs-util": "^4.0.1"
+    "ethereumjs-util": "^4.5.0"
   },
   "devDependencies": {
     "async": "^1.4.2",


### PR DESCRIPTION
We found that there was an issue with an underlying keccakjs dependency for Meteor applications. This has been addressed in the newer version of the ethereumjs-util package and so I am requesting that we use the newer version of this package (v4.5.0) to avoid these Meteor issues.