### PR TITLE
EIP155 refactor - move chainId param to txParams, parse sig for chainId

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,20 @@
 var Tx = require('ethereumjs-tx')
 var privateKey = new Buffer('e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109', 'hex')
 
-var rawTx = {
+var txParams = {
   nonce: '0x00',
   gasPrice: '0x09184e72a000', 
   gasLimit: '0x2710',
   to: '0x0000000000000000000000000000000000000000', 
   value: '0x00', 
   data: '0x7f7465737432000000000000000000000000000000000000000000000000000000600057'
+  // EIP 155 chainId - mainnet: 1, ropsten: 3
+  chainId: 3
 }
 
-var tx = new Tx(rawTx)
+var tx = new Tx(txParams)
 tx.sign(privateKey)
-
 var serializedTx = tx.serialize()
-
-
-var eip155tx = new Tx(rawTx,{chainId: 1}) //mainnet chain_id = 1
-eip155tx.sign(privateKey)
-
-var serializedEip155Tx = eip155tx.serialize()
 ```
 
 **Note:** this package expects ECMAScript 6 (ES6) as a minimum environment. From browsers lacking ES6 support, please use a shim (like [es6-shim](https://github.com/paulmillr/es6-shim)) before including any of the builds from this repo.

--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ const N_DIV_2 = new BN('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46
  * @prop {Buffer} s EC recovery ID
  */
 module.exports = class Transaction {
-  constructor (data={}) {
+  constructor (data) {
+    data = data || {}
     // Define Properties
     const fields = [{
       name: 'nonce',
@@ -123,7 +124,8 @@ module.exports = class Transaction {
    * @param {Boolean} [includeSignature=true] whether or not to inculde the signature
    * @return {Buffer}
    */
-  hash (includeSignature=true) {
+  hash (includeSignature) {
+    if (includeSignature === undefined) includeSignature = true
     // backup original signature
     const rawCopy = this.raw.slice(0)
 

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = class Transaction {
 
     // calculate chainId from signature
     let sigV = ethUtil.bufferToInt(this.v)
-    let chainId = (sigV - 35) / 2
+    let chainId = Math.floor((sigV - 35) / 2)
     if (chainId < 0) chainId = 0
 
     // set chainId

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ module.exports = class Transaction {
       this.r = 0
       this.s = 0
     }
-    
+
     // generate rlp params for hash
     let txRawForHash = includeSignature ? this.raw : this.raw.slice(0, 6)
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const N_DIV_2 = new BN('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46
  * @prop {Buffer} s EC recovery ID
  */
 module.exports = class Transaction {
-  constructor (data, opts) {
+  constructor (data={}) {
     // Define Properties
     const fields = [{
       name: 'nonce',
@@ -99,8 +99,14 @@ module.exports = class Transaction {
       configurable: true,
       get: this.getSenderAddress.bind(this)
     })
-    opts = !opts ? {chainId: 0} : opts
-    this._chainId = opts.chainId
+
+    // calculate chainId from signature
+    let sigV = ethUtil.bufferToInt(this.v)
+    let chainId = (sigV - 35) / 2
+    if (chainId < 0) chainId = 0
+
+    // set chainId
+    this._chainId = chainId || data.chainId || 0
     this._homestead = true
   }
 
@@ -114,26 +120,37 @@ module.exports = class Transaction {
 
   /**
    * Computes a sha3-256 hash of the serialized tx
-   * @param {Boolean} [signature=true] whether or not to inculde the signature
+   * @param {Boolean} [includeSignature=true] whether or not to inculde the signature
    * @return {Buffer}
    */
-  hash (signature) {
+  hash (includeSignature=true) {
+    // backup original signature
     const rawCopy = this.raw.slice(0)
-    if (this._chainId) {
+
+    // modify raw for signature generation only
+    if (this._chainId > 0) {
+      includeSignature = true
       this.v = this._chainId
-      this.r = this.s = 0
+      this.r = 0
+      this.s = 0
     }
-    let toHash
+    
+    // generate rlp params for hash
+    let txRawForHash = includeSignature ? this.raw : this.raw.slice(0, 6)
 
-    if (this._chainId || typeof signature === 'undefined') {
-      signature = true
-    }
-
-    toHash = signature ? this.raw : this.raw.slice(0, 6)
+    // restore original signature
+    this.raw = rawCopy.slice()
 
     // create hash
-    this.raw = rawCopy.slice(0)
-    return ethUtil.rlphash(toHash)
+    return ethUtil.rlphash(txRawForHash)
+  }
+
+  /**
+   * returns the public key of the sender
+   * @return {Buffer}
+   */
+  getChainId () {
+    return this._chainId
   }
 
   /**
@@ -173,9 +190,8 @@ module.exports = class Transaction {
 
     try {
       let v = ethUtil.bufferToInt(this.v)
-      if (this._chainId) {
-        v -= this._chainId * 2
-        v -= 8
+      if (this._chainId > 0) {
+        v -= this._chainId * 2 + 8
       }
       this._senderPubKey = ethUtil.ecrecover(msgHash, v, this.r, this.s)
     } catch (e) {
@@ -192,7 +208,9 @@ module.exports = class Transaction {
   sign (privateKey) {
     const msgHash = this.hash(false)
     const sig = ethUtil.ecsign(msgHash, privateKey)
-    sig.v += this._chainId ? this._chainId * 2 + 8 : 0
+    if (this._chainId > 0) {
+      sig.v += this._chainId * 2 + 8
+    }
     Object.assign(this, sig)
   }
 

--- a/test/api.js
+++ b/test/api.js
@@ -169,11 +169,17 @@ tape('[Transaction]: Basic functions', function (t) {
 
   t.test('Verify EIP155 Signature based on Vitalik\'s tests', function (st) {
     txFixturesEip155.forEach(function (tx) {
-      var pt = new Transaction(tx.rlp, { chainId: 1 })
+      var pt = new Transaction(tx.rlp)
       st.equal(pt.hash(false).toString('hex'), tx.hash)
       st.equal('0x' + pt.serialize().toString('hex'), tx.rlp)
       st.equal(pt.getSenderAddress().toString('hex'), tx.sender)
     })
+    st.end()
+  })
+
+  t.test('include chaindId in params', function (st) {
+    var tx = new Transaction({ chainId: 42 })
+    st.equal(tx.getChainId(), 42)
     st.end()
   })
 })

--- a/test/transactionRunner.js
+++ b/test/transactionRunner.js
@@ -31,7 +31,8 @@ testing.runTests(function (testData, sst, cb) {
   var tTx = testData.transaction
 
   try {
-    var tx = new Tx(new Buffer(testData.rlp.slice(2), 'hex'))
+    var rawTx = ethUtil.toBuffer(testData.rlp)
+    var tx = new Tx(rawTx)
     if (testData.blocknumber !== String(common.homeSteadForkNumber.v)) {
       tx._homestead = false
     }
@@ -41,7 +42,7 @@ testing.runTests(function (testData, sst, cb) {
     return
   }
 
-  if (tx.validate()) {
+  if (tTx && tx.validate()) {
     try {
       sst.equal(bufferToHex(tx.data), addHexPrefix(addPad(stripHexPrefix(tTx.data))), 'data')
       sst.equal(normalizeZero(bufferToHex(tx.gasLimit)), tTx.gasLimit, 'gasLimit')
@@ -57,7 +58,7 @@ testing.runTests(function (testData, sst, cb) {
       sst.fail(e)
     }
   } else {
-    sst.equal(undefined, tTx, 'should have fields ')
+    sst.equal(undefined, tTx, 'no tx params in test')
   }
   cb()
 }, txTests, tape)


### PR DESCRIPTION
This is a breaking change to the brand new EIP155 API that specified `chainId` as an extra param.
* `chainId` is now part of the txParams constructor arg.
* `chainId` is now parsed from the signature if present
* getChainId() is a public function that returns the `chainId`

builds on
https://github.com/ethereumjs/ethereumjs-tx/pull/41