### PR TITLE
EIP155 - allow v value to be greater than one byte

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,6 @@ module.exports = class Transaction {
       default: new Buffer([])
     }, {
       name: 'v',
-      length: 1,
       default: new Buffer([0x1c])
     }, {
       name: 'r',

--- a/test/api.js
+++ b/test/api.js
@@ -196,4 +196,10 @@ tape('[Transaction]: Basic functions', function (t) {
     st.equal(reTx.getChainId(), 42)
     st.end()
   })
+
+  t.test('allow chainId more than 1 byte', function (st) {
+    var tx = new Transaction({ chainId: 0x16b2 })
+    st.equal(tx.getChainId(), 0x16b2)
+    st.end()
+  })
 })


### PR DESCRIPTION
Fixes #56
also see
https://github.com/ethereum/EIPs/issues/155#issuecomment-276075645
https://github.com/ethereum/tests/issues/142