### PR TITLE
allow zeros in v,r,s signature values

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,15 +80,18 @@ class Transaction {
       default: new Buffer([])
     }, {
       name: 'v',
+      allowZero: true,
       default: new Buffer([0x1c])
     }, {
       name: 'r',
       length: 32,
+      allowZero: true,
       allowLess: true,
       default: new Buffer([])
     }, {
       name: 's',
       length: 32,
+      allowZero: true,
       allowLess: true,
       default: new Buffer([])
     }]


### PR DESCRIPTION
Needed for the [zeroSigTransactionInvChainID](https://github.com/ethereum/tests/blob/eb7cb8b97e05c2a799a457d3543a50ef1b1aa974/GeneralStateTests/stTransactionTest/zeroSigTransactionInvChainID.json#L531-L534) test case.