### PR TITLE
Move from explicit es2015 to babel preset env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [["es2015", { "loose": true, "modules": false }], "stage-0"],
+  "presets": ["env", "stage-0"],
   "compact": false
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "async": "^2.0.0",
     "babel-cli": "^6.22.2",
-    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.16.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.0",


### PR DESCRIPTION
This is both the new fancy thing to do and ensures compatibility with node code that uses -env instead of explicit es201x.