### PR TITLE
Fixed documentation for 's' and 'v' description

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,9 +13,9 @@ Creates a new transaction object.
     -   `data.to` **Buffer** to the to address
     -   `data.nonce` **Buffer** nonce number
     -   `data.data` **Buffer** this will contain the data of the message or the init of a contract
-    -   `data.v` **Buffer** EC signature parameter
+    -   `data.v` **Buffer** EC recovery ID
     -   `data.r` **Buffer** EC signature parameter
-    -   `data.s` **Buffer** EC recovery ID
+    -   `data.s` **Buffer** EC signature parameter
     -   `data.value` **Buffer** the amount of ether sent
 
 **Properties**

--- a/fake.js
+++ b/fake.js
@@ -27,9 +27,9 @@ const ethUtil = require('ethereumjs-util')
  * @prop {Buffer} to the to address
  * @prop {Buffer} value the amount of ether sent
  * @prop {Buffer} data this will contain the data of the message or the init of a contract
- * @prop {Buffer} v EC signature parameter
+ * @prop {Buffer} v EC recovery ID
  * @prop {Buffer} r EC signature parameter
- * @prop {Buffer} s EC recovery ID
+ * @prop {Buffer} s EC signature parameter
  */
 module.exports = class FakeTransaction extends Transaction {
   constructor (data) {

--- a/index.js
+++ b/index.js
@@ -37,9 +37,9 @@ const N_DIV_2 = new BN('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46
  * @param {Buffer} data.to to the to address
  * @param {Buffer} data.value the amount of ether sent
  * @param {Buffer} data.data this will contain the data of the message or the init of a contract
- * @param {Buffer} data.v EC signature parameter
+ * @param {Buffer} data.v EC recovery ID
  * @param {Buffer} data.r EC signature parameter
- * @param {Buffer} data.s EC recovery ID
+ * @param {Buffer} data.s EC signature parameter
  * @param {Number} data.chainId EIP 155 chainId - mainnet: 1, ropsten: 3
  * */
 


### PR DESCRIPTION
Switched the documentation description for 's' and 'v' parameters