### PR TITLE
Add test for verifySignature

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -51,6 +51,13 @@ tape('[Transaction]: Basic functions', function (t) {
     transactions.forEach(function (tx) {
       st.equals(tx.verifySignature(), true)
     })
+
+    st.throws(function () {
+      var tx2 = new Transaction(transactions[0].serialize())
+      tx2.r[0] += 1
+      tx2.verifySignature()
+    })
+
     st.end()
   })
 


### PR DESCRIPTION
Issue #101 
Currently `Tx#verifySignature` just recover it, not verify.
@holgerd77 [ethereumjs-util](https://github.com/ethereumjs/ethereumjs-util) does not have function for signature verification, should we add this function first?