### PR TITLE
Add a failing test for FakeTx.hash when from address is not specified

### DIFF
--- a/fake.js
+++ b/fake.js
@@ -50,7 +50,7 @@ module.exports = class FakeTransaction extends Transaction {
     })
 
     // set from address or default to null address
-    this.from = (data && data.from) ? data.from : '0x0000000000000000000000000000000000000000'
+    this.from = (data && data.from) ? data.from : '0x0000000000000000000000000000000000000001'
   }
 
   /**

--- a/test/fake.js
+++ b/test/fake.js
@@ -20,4 +20,19 @@ tape('[FakeTransaction]: Basic functions', function (t) {
     var modifiedFromFieldTxHash = utils.bufferToHex(modifiedFromFieldTx.hash())
     st.notEqual(baseTxHash, modifiedFromFieldTxHash, 'FakeTransactions with different `from` addresses but otherwise identical data should have different hashes')
   })
+
+  t.test('should handle missing from address when hashing a transaction', function (st) {
+    st.plan(0)
+    var txData = {
+      data: '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',
+      gasLimit: '0x15f90',
+      gasPrice: '0x1',
+      nonce: '0x01',
+      to: '0xd9024df085d09398ec76fbed18cac0e1149f50dc',
+      value: '0x0'
+    }
+    var tx = new FakeTransaction(txData)
+    tx.hash()
+    st.end()
+  })
 })


### PR DESCRIPTION
Adds a failing test case for #108.

Also includes a trivial "fix" by changing default `from` address to `1`.