### PR TITLE
Fix #113 (signed FakeTransaction)

### DIFF
--- a/fake.js
+++ b/fake.js
@@ -45,7 +45,9 @@ module.exports = class FakeTransaction extends Transaction {
       configurable: true,
       get: this.getSenderAddress.bind(self),
       set: function (val) {
-        self._from = ethUtil.toBuffer(val)
+        if (val) {
+          self._from = ethUtil.toBuffer(val)
+        }
       }
     })
 

--- a/test/fake.js
+++ b/test/fake.js
@@ -2,6 +2,7 @@ const tape = require('tape')
 const utils = require('ethereumjs-util')
 const FakeTransaction = require('../fake.js')
 
+// Use private key 0x0000000000000000000000000000000000000000000000000000000000000001 as 'from' Account
 var txData = {
   data: '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',
   gasLimit: '0x15f90',
@@ -9,7 +10,10 @@ var txData = {
   nonce: '0x01',
   to: '0xd9024df085d09398ec76fbed18cac0e1149f50dc',
   value: '0x0',
-  from: '0x1111111111111111111111111111111111111111'
+  from: '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf',
+  v: '0x1c',
+  r: '0x25641558260ac737ea6d800906c6d085a801e5e0f0952bf93978d6fa468fbdfe',
+  s: '0x5d0904b8f9cfc092805df0cde2574d25e2c5fc28907a9a4741b3e857b68b0778'
 }
 
 tape('[FakeTransaction]: Basic functions', function (t) {
@@ -17,7 +21,7 @@ tape('[FakeTransaction]: Basic functions', function (t) {
     st.plan(3)
     var tx = new FakeTransaction(txData)
     var hash = tx.hash()
-    var cmpHash = Buffer.from('f0327c058946be12609d2afc0c45e8e1fffe57acbbff0e9c252e8fab61c3b2b9', 'hex')
+    var cmpHash = Buffer.from('f74b039f6361c4351a99a7c6a10867369fe6701731d85dc07c15671ac1c1b648', 'hex')
     st.deepEqual(hash, cmpHash, 'should create hash with includeSignature=true (default)')
     var hash2 = tx.hash(false)
     var cmpHash2 = Buffer.from('0401bf740d698674be321d0064f92cd6ebba5d73d1e5e5189c0bebbda33a85fe', 'hex')
@@ -31,7 +35,7 @@ tape('[FakeTransaction]: Basic functions', function (t) {
     st.plan(3)
     var tx = new FakeTransaction(txDataNoFrom)
     var hash = tx.hash()
-    var cmpHash = Buffer.from('7521eb94880840a93e2105f064cec3fe605f0159778a420b9b529c2f3d3b4e37', 'hex')
+    var cmpHash = Buffer.from('80a2ca70509414908881f718502e6bbb3bc67f416abdf972ea7c0888579be7b9', 'hex')
     st.deepEqual(hash, cmpHash, 'should create hash with includeSignature=true (default)')
     var hash2 = tx.hash(false)
     var cmpHash2 = Buffer.from('0401bf740d698674be321d0064f92cd6ebba5d73d1e5e5189c0bebbda33a85fe', 'hex')
@@ -47,5 +51,14 @@ tape('[FakeTransaction]: Basic functions', function (t) {
     var hash = utils.bufferToHex(tx.hash())
     var hashModFrom = utils.bufferToHex(txModFrom.hash())
     st.notEqual(hash, hashModFrom, 'FakeTransactions with different `from` addresses but otherwise identical data should have different hashes')
+  })
+
+  t.test('should retrieve "from" from signature if transaction is signed', function (st) {
+    var txDataNoFrom = Object.assign({}, txData)
+    delete txDataNoFrom['from']
+    st.plan(1)
+
+    var tx = new FakeTransaction(txDataNoFrom)
+    st.equal(utils.bufferToHex(tx.from), txData.from)
   })
 })


### PR DESCRIPTION
Also serves as a contribution towards #114 .

This issue, discussed in #113, has a simple fix; a null check on the `from` setter. The bug is that if `self._from` is initialized to `ethereumjs-util.toBuffer(null)`, it will contain a buffer object that represents '0'. Then if you call `FakeTransaction.from`, the getter will return that empty buffer object here (in `getSenderAddress()`):
```
if (this._from) {
  return this._from
}
```

This issue is currently preventing self-signed transactions from being submitted to ganache.