### PR TITLE
Update official transaction tests to run with latest ethereumjs-testing (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "contributor": "^0.1.25",
     "coveralls": "^2.11.4",
     "documentation": "^3.0.4",
-    "ethereumjs-testing": "0.0.1",
+    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.5",
     "istanbul": "^0.4.1",
     "karma": "^1.1.1",
     "karma-browserify": "^5.1.0",

--- a/test/transactionRunner.js
+++ b/test/transactionRunner.js
@@ -1,64 +1,55 @@
-const Tx = require('../index.js')
+const Tx = require('./index.js')
 const tape = require('tape')
 const ethUtil = require('ethereumjs-util')
-const argv = require('minimist')(process.argv.slice(2))
 const testing = require('ethereumjs-testing')
-const common = require('ethereum-common/params.json')
 
-var txTests = testing.getTests('transaction', argv)
+const forkNames = [
+  'Byzantium',
+  'Constantinople',
+  'EIP150',
+  'EIP158',
+  'Frontier',
+  'Homestead'
+]
 
-const bufferToHex = ethUtil.bufferToHex
-const addHexPrefix = ethUtil.addHexPrefix
-const stripHexPrefix = ethUtil.stripHexPrefix
-const setLength = ethUtil.setLength
+tape('TransactionTests', (t) => {
+  testing.getTests('TransactionTests', (testName, testData) => {
+    let rawTx
+    let tx
+    t.test(`${testName}: creates tx`, (st) => {
+      try {
+        rawTx = ethUtil.toBuffer(testData.rlp)
+        tx = new Tx(rawTx)
+        if (Object.keys(testData.Homestead).length === 0) {
+          tx._homestead = false
+        }
+      } catch (e) {
+        st.equal(undefined, tx, 'should not have any fields ')
+        st.end()
+      }
+    })
 
-function addPad (v) {
-  if (v.length % 2 === 1) {
-    v = '0' + v
-  }
-  return v
-}
-
-function normalizeZero (v) {
-  if (!v || v === '0x') {
-    return '0x00'
-  } else {
-    return v
-  }
-}
-
-testing.runTests(function (testData, sst, cb) {
-  var tTx = testData.transaction
-
-  try {
-    var rawTx = ethUtil.toBuffer(testData.rlp)
-    var tx = new Tx(rawTx)
-    if (testData.blocknumber !== String(common.homeSteadForkNumber.v)) {
-      tx._homestead = false
-    }
-  } catch (e) {
-    sst.equal(undefined, tTx, 'should not have any fields ')
-    cb()
-    return
-  }
-
-  if (tTx && tx.validate()) {
-    try {
-      sst.equal(bufferToHex(tx.data), addHexPrefix(addPad(stripHexPrefix(tTx.data))), 'data')
-      sst.equal(normalizeZero(bufferToHex(tx.gasLimit)), tTx.gasLimit, 'gasLimit')
-      sst.equal(normalizeZero(bufferToHex(tx.gasPrice)), tTx.gasPrice, 'gasPrice')
-      sst.equal(normalizeZero(bufferToHex(tx.nonce)), tTx.nonce, 'nonce')
-      sst.equal(normalizeZero(bufferToHex(setLength(tx.r, 32))), normalizeZero(bufferToHex(setLength(tTx.r, 32))), 'r')
-      sst.equal(normalizeZero(bufferToHex(tx.s)), normalizeZero(bufferToHex(tTx.s)), 's')
-      sst.equal(normalizeZero(bufferToHex(tx.v)), normalizeZero(bufferToHex(tTx.v)), 'v')
-      sst.equal(bufferToHex(tx.to), addHexPrefix(tTx.to), 'to')
-      sst.equal(normalizeZero(bufferToHex(tx.value)), tTx.value, 'value')
-      sst.equal(normalizeZero(bufferToHex(tx.getSenderAddress())), addHexPrefix(testData.sender), "sender's address")
-    } catch (e) {
-      sst.fail(e)
-    }
-  } else {
-    sst.equal(undefined, tTx, 'no tx params in test')
-  }
-  cb()
-}, txTests, tape)
+    let sender
+    let hash
+    t.test(`${testName}: tx has correct data`, (st) => {
+      if (tx && tx.validate()) {
+        sender = tx.getSenderAddress().toString('hex')
+        hash = tx.hash().toString('hex')
+        try {
+          forkNames.forEach(forkName => {
+            st.equal(testData[forkName].sender, sender)
+            st.equal(testData[forkName].hash, hash)
+          })
+        } catch (e) {
+          st.fail(e)
+        }
+      } else {
+        st.equal(undefined, tx, 'no tx params in test')
+      }
+      st.end()
+    })
+  })
+  .then(() => {
+    t.end()
+  })
+})


### PR DESCRIPTION
fixes #115 

Updates the `transactionRunner.js` tests as per the changes and instructions described here: https://github.com/ethereum/tests/issues/373

This is a work in progress. There are two things I need to verify:
- that this test runner is covering all cases that the removed one covered
- that the fact that no tests are failing due to EIP-155 is a problem on ethereum/tests

To do:
- have the test properly handle command line args