### PR TITLE
Fix Karma for users with more browsers than firefox

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,7 +21,10 @@ module.exports = function (config) {
     ],
     detectBrowsers: {
       enabled: true,
-      usePhantomJS: false
+      usePhantomJS: false,
+      postDetection: function (availableBrowsers) {
+        return [ 'Firefox' ]
+      }
     }
   })
 }


### PR DESCRIPTION
Given the current set up, Karma tests will not run locally for users with more browsers than Firefox. This is because Karma requires a launcher for each browser it detects.

This PR fixes this by forcing Karma to only use Firefox.