### PR TITLE
Allow specification of test suite via command line arg.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,13 @@
-require('./fake.js')
-require('./api.js')
-require('./transactionRunner.js')
+const argv = require('minimist')(process.argv.slice(2))
+
+if (argv.f) {
+  require('./fake.js')
+} else if (argv.a) {
+  require('./api.js')
+} else if (argv.t) {
+  require('./transactionRunner.js')
+} else {
+  require('./fake.js')
+  require('./api.js')
+  require('./transactionRunner.js')
+}


### PR DESCRIPTION
While working on https://github.com/ethereumjs/ethereumjs-tx/pull/126/, it seemed it would be nice if we could run just one of the test files at a time. This PR is a small change that allows us to provide a command line arg to the `test:node` command. For example: `npm run test:node -- -t` will run only the tests in `test/transactionRunner.js`.