### PR TITLE
Update official transaction tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,11 @@ class Transaction {
     if (chainId < 0) chainId = 0
 
     // set chainId
-    this._chainId = chainId || data.chainId || 0
+    if (opts.chain || opts.common) {
+      this._chainId = this._common.chainId()
+    } else {
+      this._chainId = chainId || data.chainId || 0
+    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "contributor": "^0.1.25",
     "coveralls": "^2.11.4",
     "documentation": "^8.0.0",
-    "ethereumjs-testing": "0.0.1",
+    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.5",
     "istanbul": "^0.4.1",
     "karma": "^1.1.1",
     "karma-browserify": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "author": "mjbecze <mb@ethdev.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "ethereumjs-common": "^0.6.1",
-    "ethereumjs-util": "^5.0.0"
+    "ethereumjs-common": "^1.0.0",
+    "ethereumjs-util": "^6.0.0"
   },
   "devDependencies": {
     "async": "^2.0.0",

--- a/test/fake.js
+++ b/test/fake.js
@@ -1,6 +1,6 @@
 const tape = require('tape')
 const utils = require('ethereumjs-util')
-const Common = require('ethereumjs-common')
+const Common = require('ethereumjs-common').default
 const FakeTransaction = require('../fake.js')
 
 // Use private key 0x0000000000000000000000000000000000000000000000000000000000000001 as 'from' Account

--- a/test/transactionRunner.js
+++ b/test/transactionRunner.js
@@ -14,10 +14,10 @@ const forkNames = [
 ]
 
 tape('TransactionTests', (t) => {
-  testing.getTests('TransactionTests', (testName, testData) => {
+  testing.getTests('TransactionTests', (filename, testName, testData) => {
     let rawTx
     let tx
-    t.test(`${testName}: creates tx`, (st) => {
+    t.test(testName, (st) => {
       try {
         rawTx = ethUtil.toBuffer(testData.rlp)
         tx = new Tx(rawTx)
@@ -28,11 +28,10 @@ tape('TransactionTests', (t) => {
         st.equal(undefined, tx, 'should not have any fields ')
         st.end()
       }
-    })
 
-    let sender
-    let hash
-    t.test(`${testName}: tx has correct data`, (st) => {
+      let sender
+      let hash
+
       if (tx && tx.validate()) {
         sender = tx.getSenderAddress().toString('hex')
         hash = tx.hash().toString('hex')

--- a/test/transactionRunner.js
+++ b/test/transactionRunner.js
@@ -40,6 +40,7 @@ tape('TransactionTests', (t) => {
         try {
           tx = new Tx(rawTx, {
             hardfork: forkNameMap[forkName],
+            chain: 1,
           })
 
           const sender = tx.getSenderAddress().toString('hex')

--- a/test/transactionRunner.js
+++ b/test/transactionRunner.js
@@ -10,7 +10,7 @@ const forkNames = [
   'EIP150',
   'EIP158',
   'Frontier',
-  'Homestead',
+  'Homestead'
 ]
 
 const forkNameMap = {
@@ -19,28 +19,24 @@ const forkNameMap = {
   EIP150: 'tangerineWhistle',
   EIP158: 'spuriousDragon',
   Frontier: 'chainstart',
-  Homestead: 'homestead',
+  Homestead: 'homestead'
 }
 
 tape('TransactionTests', (t) => {
   const fileFilterRegex = argv.file ? new RegExp(argv.file + '[^\\w]') : undefined
 
   testing.getTests('TransactionTests', (filename, testName, testData) => {
-    let rawTx
-    let tx
     t.test(testName, (st) => {
       const rawTx = ethUtil.toBuffer(testData.rlp)
 
       let tx
-      let sender
-      let hash
       forkNames.forEach(forkName => {
         const forkTestData = testData[forkName]
         const shouldBeInvalid = Object.keys(forkTestData).length === 0
         try {
           tx = new Tx(rawTx, {
             hardfork: forkNameMap[forkName],
-            chain: 1,
+            chain: 1
           })
 
           const sender = tx.getSenderAddress().toString('hex')

--- a/test/transactionRunner.js
+++ b/test/transactionRunner.js
@@ -14,6 +14,8 @@ const forkNames = [
 ]
 
 tape('TransactionTests', (t) => {
+  const fileFilterRegex = argv.file ? new RegExp(argv.file + '[^\\w]') : undefined
+
   testing.getTests('TransactionTests', (filename, testName, testData) => {
     let rawTx
     let tx
@@ -41,7 +43,7 @@ tape('TransactionTests', (t) => {
       })
       st.end()
     })
-  })
+  }, fileFilterRegex)
   .then(() => {
     t.end()
   })


### PR DESCRIPTION
Opening this PR instead of https://github.com/ethereumjs/ethereumjs-tx/pull/126 as this branch is in the main repo.

fixes #115

Updates the transactionRunner.js tests as per the changes and instructions described here: ethereum/tests#373

Each test is run for each of the hardforks. If the `tx` is defined but has an invalid signature after creation, the test passes if the test data for the given hardfork is empty. If the `tx` is undefined after creation, the test passes if the test data for the given hardfork is empty. If the `tx` has a sender and hash that matches that in the test data for the given hard fork, the test passes.

This PR also adds the ability to run a single test by passing an exact filename match. For example:
`npm run test:node -- -t --file=TransactionWithHighGas | tap-spec`