### PR TITLE
Support spurious dragon and later

### DIFF
--- a/fake.js
+++ b/fake.js
@@ -32,8 +32,8 @@ const ethUtil = require('ethereumjs-util')
  * @prop {Buffer} s EC signature parameter
  */
 module.exports = class FakeTransaction extends Transaction {
-  constructor (data) {
-    super(data)
+  constructor (data, opts) {
+    super(data, opts)
 
     var self = this
 

--- a/index.js
+++ b/index.js
@@ -278,8 +278,8 @@ class Transaction {
     const cost = new BN(0)
     for (let i = 0; i < data.length; i++) {
       data[i] === 0
-        ? cost.iaddn(common.param('gasPrices', 'txDataZero'))
-        : cost.iaddn(common.param('gasPrices', 'txDataNonZero'))
+        ? cost.iaddn(this._common.param('gasPrices', 'txDataZero'))
+        : cost.iaddn(this._common.param('gasPrices', 'txDataNonZero'))
     }
     return cost
   }
@@ -289,9 +289,9 @@ class Transaction {
    * @return {BN}
    */
   getBaseFee () {
-    const fee = this.getDataFee().iaddn(common.param('gasPrices', 'tx'))
+    const fee = this.getDataFee().iaddn(this._common.param('gasPrices', 'tx'))
     if (this._homestead && this.toCreationAddress()) {
-      fee.iaddn(common.param('gasPrices', 'txCreation'))
+      fee.iaddn(this._common.param('gasPrices', 'txCreation'))
     }
     return fee
   }

--- a/index.js
+++ b/index.js
@@ -3,9 +3,6 @@ const ethUtil = require('ethereumjs-util')
 const Common = require('ethereumjs-common')
 const BN = ethUtil.BN
 
-// instantiate Common class instance
-const common = new Common('mainnet', 'chainstart')
-
 // secp256k1n/2
 const N_DIV_2 = new BN('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0', 16)
 
@@ -52,7 +49,25 @@ const N_DIV_2 = new BN('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46
  * */
 
 class Transaction {
-  constructor (data) {
+  constructor (data, opts) {
+    opts = opts || {}
+
+    // instantiate Common class instance based on passed options
+    if (opts.common) {
+      if (opts.chain) {
+        throw new Error('Instantiation with both opts.common and opts.chain parameter not allowed!')
+      }
+      this._common = opts.common
+    } else {
+      let chain = opts.chain ? opts.chain : 'mainnet'
+      let hardfork = opts.hardfork ? opts.hardfork : 'byzantium'
+      let supportedHardforks = [
+        'byzantium',
+        'constantinople'
+      ]
+      this._common = new Common(chain, hardfork, supportedHardforks)
+    }
+
     data = data || {}
     // Define Properties
     const fields = [{

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const ethUtil = require('ethereumjs-util')
-const fees = require('ethereum-common/params.json')
+const { gasPrices: fees } = require('ethereumjs-common/hardforks/chainstart.json')
 const BN = ethUtil.BN
 
 // secp256k1n/2
@@ -254,7 +254,7 @@ class Transaction {
     const data = this.raw[5]
     const cost = new BN(0)
     for (let i = 0; i < data.length; i++) {
-      data[i] === 0 ? cost.iaddn(fees.txDataZeroGas.v) : cost.iaddn(fees.txDataNonZeroGas.v)
+      data[i] === 0 ? cost.iaddn(fees.txDataZero.v) : cost.iaddn(fees.txDataNonZero.v)
     }
     return cost
   }
@@ -264,7 +264,7 @@ class Transaction {
    * @return {BN}
    */
   getBaseFee () {
-    const fee = this.getDataFee().iaddn(fees.txGas.v)
+    const fee = this.getDataFee().iaddn(fees.tx.v)
     if (this._homestead && this.toCreationAddress()) {
       fee.iaddn(fees.txCreation.v)
     }

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ class Transaction {
 
     // set chainId
     this._chainId = chainId || data.chainId || 0
-    this._homestead = true
+    this._homestead = this._common.gteHardfork('homestead')
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -44,6 +44,11 @@ const N_DIV_2 = new BN('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46
  * @param {Buffer} data.r EC signature parameter
  * @param {Buffer} data.s EC signature parameter
  * @param {Number} data.chainId EIP 155 chainId - mainnet: 1, ropsten: 3
+ *
+ * @param {Array} opts Options
+ * @param {String|Number} opts.chain The chain for the block [default: 'mainnet']
+ * @param {String} opts.hardfork Hardfork for the block [default: null, block number-based behaviour]
+ * @param {Object} opts.common Alternatively pass a Common instance (ethereumjs-common) instead of setting chain/hardfork directly
  * */
 
 class Transaction {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict'
 const ethUtil = require('ethereumjs-util')
-const { gasPrices: fees } = require('ethereumjs-common/hardforks/chainstart.json')
+const Common = require('ethereumjs-common')
 const BN = ethUtil.BN
+
+// instantiate Common class instance
+const common = new Common('mainnet', 'chainstart')
 
 // secp256k1n/2
 const N_DIV_2 = new BN('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0', 16)
@@ -254,7 +257,9 @@ class Transaction {
     const data = this.raw[5]
     const cost = new BN(0)
     for (let i = 0; i < data.length; i++) {
-      data[i] === 0 ? cost.iaddn(fees.txDataZero.v) : cost.iaddn(fees.txDataNonZero.v)
+      data[i] === 0
+        ? cost.iaddn(common.param('gasPrices', 'txDataZero'))
+        : cost.iaddn(common.param('gasPrices', 'txDataNonZero'))
     }
     return cost
   }
@@ -264,9 +269,9 @@ class Transaction {
    * @return {BN}
    */
   getBaseFee () {
-    const fee = this.getDataFee().iaddn(fees.tx.v)
+    const fee = this.getDataFee().iaddn(common.param('gasPrices', 'tx'))
     if (this._homestead && this.toCreationAddress()) {
-      fee.iaddn(fees.txCreation.v)
+      fee.iaddn(common.param('gasPrices', 'txCreation'))
     }
     return fee
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "mjbecze <mb@ethdev.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "ethereum-common": "^0.0.18",
+    "ethereumjs-common": "^0.6.1",
     "ethereumjs-util": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "ethereumjs-common": "^0.6.1",
-    "ethereumjs-util": "^5.0.0"
+    "ethereumjs-util": "^6.0.0"
   },
   "devDependencies": {
     "async": "^2.0.0",

--- a/test/fake.js
+++ b/test/fake.js
@@ -70,7 +70,7 @@ tape('[FakeTransaction]: Basic functions', function (t) {
       common: new Common('mainnet', 'chainstart')
     }
     st.plan(1)
-    t.throws(
+    st.throws(
       () => new FakeTransaction(txData, txOptsInvalid),
       'Instantiation with both opts.common and opts.chain parameter not allowed!'
     )

--- a/test/fake.js
+++ b/test/fake.js
@@ -1,5 +1,6 @@
 const tape = require('tape')
 const utils = require('ethereumjs-util')
+const Common = require('ethereumjs-common')
 const FakeTransaction = require('../fake.js')
 
 // Use private key 0x0000000000000000000000000000000000000000000000000000000000000001 as 'from' Account
@@ -60,5 +61,18 @@ tape('[FakeTransaction]: Basic functions', function (t) {
 
     var tx = new FakeTransaction(txDataNoFrom)
     st.equal(utils.bufferToHex(tx.from), txData.from)
+  })
+
+  t.test('should throw if common and chain options are passed to constructor', function (st) {
+    var txData = Object.assign({}, txData)
+    var txOptsInvalid = {
+      chain: 'mainnet',
+      common: new Common('mainnet', 'chainstart')
+    }
+    st.plan(1)
+    t.throws(
+      () => new FakeTransaction(txData, txOptsInvalid),
+      'Instantiation with both opts.common and opts.chain parameter not allowed!'
+    )
   })
 })

--- a/test/fake.js
+++ b/test/fake.js
@@ -71,8 +71,7 @@ tape('[FakeTransaction]: Basic functions', function (t) {
     }
     st.plan(1)
     st.throws(
-      () => new FakeTransaction(txData, txOptsInvalid),
-      'Instantiation with both opts.common and opts.chain parameter not allowed!'
+      () => new FakeTransaction(txData, txOptsInvalid)
     )
   })
 })

--- a/test/transactionRunner.js
+++ b/test/transactionRunner.js
@@ -3,10 +3,12 @@ const tape = require('tape')
 const ethUtil = require('ethereumjs-util')
 const argv = require('minimist')(process.argv.slice(2))
 const testing = require('ethereumjs-testing')
-const common = require('ethereum-common/params.json')
+const { hardforks } = require('ethereumjs-common/chains/mainnet.json')
 
 var txTests = testing.getTests('transaction', argv)
 
+const homesteadIndex = 1
+const homestead = hardforks[homesteadIndex]
 const bufferToHex = ethUtil.bufferToHex
 const addHexPrefix = ethUtil.addHexPrefix
 const stripHexPrefix = ethUtil.stripHexPrefix
@@ -33,7 +35,7 @@ testing.runTests(function (testData, sst, cb) {
   try {
     var rawTx = ethUtil.toBuffer(testData.rlp)
     var tx = new Tx(rawTx)
-    if (testData.blocknumber !== String(common.homeSteadForkNumber.v)) {
+    if (testData.blocknumber !== String(homestead.block)) {
       tx._homestead = false
     }
   } catch (e) {

--- a/test/transactionRunner.js
+++ b/test/transactionRunner.js
@@ -3,10 +3,6 @@ const tape = require('tape')
 const ethUtil = require('ethereumjs-util')
 const argv = require('minimist')(process.argv.slice(2))
 const testing = require('ethereumjs-testing')
-const Common = require('ethereumjs-common')
-
-// instantiate Common class instance
-const common = new Common('mainnet', 'chainstart')
 
 var txTests = testing.getTests('transaction', argv)
 
@@ -36,9 +32,6 @@ testing.runTests(function (testData, sst, cb) {
   try {
     var rawTx = ethUtil.toBuffer(testData.rlp)
     var tx = new Tx(rawTx)
-    if (!common.isHardforkBlock(testData.blocknumber, 'homestead')) {
-      tx._homestead = false
-    }
   } catch (e) {
     sst.equal(undefined, tTx, 'should not have any fields ')
     cb()

--- a/test/transactionRunner.js
+++ b/test/transactionRunner.js
@@ -3,12 +3,13 @@ const tape = require('tape')
 const ethUtil = require('ethereumjs-util')
 const argv = require('minimist')(process.argv.slice(2))
 const testing = require('ethereumjs-testing')
-const { hardforks } = require('ethereumjs-common/chains/mainnet.json')
+const Common = require('ethereumjs-common')
+
+// instantiate Common class instance
+const common = new Common('mainnet', 'chainstart')
 
 var txTests = testing.getTests('transaction', argv)
 
-const homesteadIndex = 1
-const homestead = hardforks[homesteadIndex]
 const bufferToHex = ethUtil.bufferToHex
 const addHexPrefix = ethUtil.addHexPrefix
 const stripHexPrefix = ethUtil.stripHexPrefix
@@ -35,7 +36,7 @@ testing.runTests(function (testData, sst, cb) {
   try {
     var rawTx = ethUtil.toBuffer(testData.rlp)
     var tx = new Tx(rawTx)
-    if (testData.blocknumber !== String(homestead.block)) {
+    if (!common.isHardforkBlock(testData.blocknumber, 'homestead')) {
       tx._homestead = false
     }
   } catch (e) {


### PR DESCRIPTION
This PR builds off the changes in #130 and is needed to get a number of tests passing after the test rewrite in #131 

Before this can be merged, we will need to merged those and rebase this on top of it. I am posting this PR now as the code changes were useful to me in verifying the work of #130 and #131 

It should be noted that there are still failures from 12 test files after this PR. All of these failures are cases where the transaction should be invalid on 'Byzantium', 'Constantinople', and 'EIP158'/spuriousDragon. However I have spent an significant amount of time investigating those failures and cannot determine there cause. In fact, the transactions from at least two of these test cases are valid when creating them from their test file data in geth (https://github.com/ethereum/go-ethereum/compare/master...danjm:demo-WrongVRSTestVEqual39-validity?expand=1) even though the test file asserts that they should be invalid.

I will continue to investigate these issues, however we may wish to merge this PR before the final test cases are resolved, as this PR increase our overall coverage/support for 'Byzantium', 'Constantinople', and 'EIP158'/spuriousDragon