### PR TITLE
Org links and git hooks

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Great that you want to contribute to the `EthereumJS` [ecosystem](https://ethereumjs.readthedocs.io/en/latest/introduction.html). `EthereumJS` is managed by the Ethereum Foundation and largely driven by the wider community. Everyone is welcome to join the effort and help to improve on the libraries (see our [Code of Conduct](https://ethereumjs.readthedocs.io/en/latest/code_of_conduct.html) 🌷).
+
+We have written up some [Contribution Guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html#how-to-start) to help you getting started.
+
+These include information on how we work with **Git** and how our **general workflow** and **technical setup** looks like (stuff like language, tooling, code quality and style).
+
+Happy Coding! 👾 😀 💻

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ For a browser build please see https://github.com/ethereumjs/browser-builds.
 
 [./docs/](./docs/README.md)
 
+# EthereumJS
+
+See our organizational [documentation](https://ethereumjs.readthedocs.io) for an introduction to `EthereumJS` as well as information on current standards and best practices.
+
+If you want to join for work or do improvements on the libraries have a look at our [contribution guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html).
+
 # LICENSE
 
 [MPL-2.0](<https://tldrlegal.com/license/mozilla-public-license-2.0-(mpl-2)>)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "test:browser:build": "tsc && cp ./test/*.json test-build/test/",
     "test:browser": "npm run test:browser:build && karma start karma.conf.js"
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run lint"
+    }
+  },
   "keywords": [
     "ethereum",
     "transactions"
@@ -48,6 +53,7 @@
     "contributor": "^0.1.25",
     "coveralls": "^2.11.4",
     "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.8",
+    "husky": "^2.1.0",
     "istanbul": "^0.4.1",
     "karma": "^4.1.0",
     "karma-browserify": "^6.0.0",


### PR DESCRIPTION
Organization wide application of GitHooks https://github.com/ethereumjs/ethereumjs-account/pull/46 and organizational docs linking https://github.com/ethereumjs/ethereumjs-account/pull/49.