### PR TITLE
Simplify transaction's constructor and EIP155 handling

### DIFF
--- a/src/fake.ts
+++ b/src/fake.ts
@@ -7,8 +7,7 @@ import Transaction from './transaction'
  * Creates a new transaction object that doesn't need to be signed.
  *
  * @param data - A transaction can be initialized with its rlp representation, an array containing
- * the value of its fields in order, or an object containing them by name. If the latter is used,
- * a `chainId` and `from` can also be provided.
+ * the value of its fields in order, or an object containing them by name.
  *
  * @param opts - The transaction's options, used to indicate the chain and hardfork the
  * transactions belongs to.

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -260,6 +260,12 @@ export default class Transaction {
    * @param privateKey - Must be 32 bytes in length
    */
   sign(privateKey: Buffer) {
+    // We clear any previous signature before signing it. Otherwise, _implementsEIP155's can give
+    // different results if this tx was already signed.
+    this.v = new Buffer([])
+    this.s = new Buffer([])
+    this.r = new Buffer([])
+
     const msgHash = this.hash(false)
     const sig = ecsign(msgHash, privateKey)
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -40,8 +40,7 @@ export default class Transaction {
    * Creates a new transaction from an object with its fields' values.
    *
    * @param data - A transaction can be initialized with its rlp representation, an array containing
-   * the value of its fields in order, or an object containing them by name. If the latter is used,
-   * a `chainId` can also be provided.
+   * the value of its fields in order, or an object containing them by name.
    *
    * @param opts - The transaction's options, used to indicate the chain and hardfork the
    * transactions belongs to.

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -145,15 +145,6 @@ export default class Transaction {
       },
     ]
 
-    /**
-     * Returns the transaction in JSON format
-     * @method toJSON
-     * @return {Array | String}
-     * @memberof Transaction
-     * @name toJSON
-     * @see {@link https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/index.md#defineproperties|ethereumjs-util}
-     */
-
     // attached serialize
     defineProperties(this, fields, data)
 
@@ -340,6 +331,15 @@ export default class Transaction {
   serialize(): Buffer {
     // Note: This never gets executed, defineProperties overwrites it.
     return rlp.encode(this.raw)
+  }
+
+  /**
+   * Returns the transaction in JSON format
+   * @see {@link https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/index.md#defineproperties|ethereumjs-util}
+   */
+  toJSON(labels: boolean = false): { [key: string]: string } | string[] {
+    // Note: This never gets executed, defineProperties overwrites it.
+    return {}
   }
 
   private _validateV(v?: Buffer): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,11 +23,6 @@ export type BufferLike = Buffer | TransformableToBuffer | PrefixedHexString | nu
  */
 export interface TxData {
   /**
-   * EIP 155 chainId - mainnet: 1, ropsten: 3
-   */
-  chainId?: number
-
-  /**
    * The transaction's gas limit.
    */
   gasLimit?: BufferLike

--- a/test/api.ts
+++ b/test/api.ts
@@ -296,7 +296,7 @@ tape('[Transaction]: Basic functions', function(t) {
     st.end()
   })
 
-  t.test('If chain/hardfork and commmon options are given', function(st) {
+  t.test('Throws if chain/hardfork and commmon options are given', function(st) {
     st.throws(
       () => new Transaction({}, { common: new Common('mainnet', 'petersburg'), chain: 'mainnet' }),
     )
@@ -310,6 +310,21 @@ tape('[Transaction]: Basic functions', function(t) {
           { common: new Common('mainnet', 'petersburg'), hardfork: 'petersburg' },
         ),
     )
+    st.end()
+  })
+
+  t.test('Throws if v is set to an EIP155-encoded value incompatible with the chain id', function(
+    st,
+  ) {
+    const tx = new Transaction({}, { chain: 42 })
+    const privKey = new Buffer(txFixtures[0].privateKey, 'hex')
+    tx.sign(privKey)
+
+    st.throws(() => (tx.v = toBuffer(1)))
+
+    const unsignedTx = new Transaction(tx.raw.slice(0, 6))
+    st.throws(() => (unsignedTx.v = tx.v))
+
     st.end()
   })
 

--- a/test/api.ts
+++ b/test/api.ts
@@ -231,6 +231,10 @@ tape('[Transaction]: Basic functions', function(t) {
       'hex',
     )
     const pt = new Transaction(txRaw)
+
+    // Note that Vitalik's example has a very similar value denoted "signing data". It's not the
+    // output of `serialize()`, but the pre-image of the hash returned by `tx.hash(false)`.
+    // We don't have a getter for such a value in Transaction.
     st.equal(
       pt.serialize().toString('hex'),
       'ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080808080',

--- a/test/fake.ts
+++ b/test/fake.ts
@@ -149,7 +149,7 @@ tape('[FakeTransaction]: Basic functions', function(t) {
       '31718e6bf821a98d35b0d9cd66ea86f91f420c3c4658f60c607222de925d222a',
       's should be valid',
     )
-    st.equal(tx.v.toString('hex'), '26', 'v should be valid')
+    st.equal(tx.v.toString('hex'), '1c', 'v should be valid')
   })
 
   t.test('should getDataFee', st => {

--- a/test/fake.ts
+++ b/test/fake.ts
@@ -136,7 +136,7 @@ tape('[FakeTransaction]: Basic functions', function(t) {
   })
 
   t.test('should sign', st => {
-    const tx = new FakeTransaction(txData)
+    const tx = new FakeTransaction(txData, { hardfork: 'tangerineWhistle' })
     tx.sign(Buffer.from('164122e5d39e9814ca723a749253663bafb07f6af91704d9754c361eb315f0c1', 'hex'))
     st.plan(3)
     st.equal(

--- a/test/fake.ts
+++ b/test/fake.ts
@@ -22,7 +22,8 @@ const txData: FakeTxData = {
 tape('[FakeTransaction]: Basic functions', function(t) {
   t.test('instantiate with from / create a hash', function(st) {
     st.plan(3)
-    const tx = new FakeTransaction(txData)
+    // This test doesn't use EIP155
+    const tx = new FakeTransaction(txData, { chain: 'mainnet', hardfork: 'homestead' })
     const hash = tx.hash()
     const cmpHash = Buffer.from(
       'f74b039f6361c4351a99a7c6a10867369fe6701731d85dc07c15671ac1c1b648',
@@ -102,12 +103,10 @@ tape('[FakeTransaction]: Basic functions', function(t) {
 
   t.test('should return getChainId', st => {
     const tx = new FakeTransaction(txData)
-    const txWithV = new FakeTransaction({ ...txData, v: '0x28' })
-    const txWithChainId = new FakeTransaction({ ...txData, chainId: 4 })
-    st.plan(3)
-    st.equal(tx.getChainId(), 0, 'should return correct chainId')
-    st.equal(txWithV.getChainId(), 2, 'should return correct chainId')
-    st.equal(txWithChainId.getChainId(), 4, 'should return correct chainId')
+    const txWithChain = new FakeTransaction(txData, { chain: 3 })
+    st.plan(2)
+    st.equal(tx.getChainId(), 1, 'should return correct chainId')
+    st.equal(txWithChain.getChainId(), 3, 'should return correct chainId')
   })
 
   t.test('should getSenderAddress and getSenderPublicKey', st => {
@@ -150,7 +149,7 @@ tape('[FakeTransaction]: Basic functions', function(t) {
       '31718e6bf821a98d35b0d9cd66ea86f91f420c3c4658f60c607222de925d222a',
       's should be valid',
     )
-    st.equal(tx.v.toString('hex'), '1c', 'v should be valid')
+    st.equal(tx.v.toString('hex'), '26', 'v should be valid')
   })
 
   t.test('should getDataFee', st => {


### PR DESCRIPTION
This PR implements the changes discussed in the [TS migration PR](https://github.com/ethereumjs/ethereumjs-tx/pull/145) and in fixes #149.

A summary of the changes:

1. chainId can't be provided in the `data` object.
2. Only `opts.common`, or `opts.chain` and `opts.hardfork` can be used.
3. The default hardfork is now `'petersburg'`.
4. The chain id is always obtained from the internal `common` object now. It isn't computed in the constructor.
5. The constructor throws if the `v` value is present, indicates that EIP155 was enabled, and the chain id it indicates doesn't match the one of the internal `common` object.
6. No default `v` is set. If a transaction isn't signed, it would be an empty buffer.
7. Transactions are always signed with EIP155 after Spurios Dragon.
8. If `v` is changed after construction, ~~and it doesn't match the one of the internal `common` object, we throw a clear message in `tx.verifySignature()` instead of just letting it return false.~~ its value is validated in its setter.

I think (7) and (8) require some extra comments:

(7) This is different from the previous implementation, where by default EIP155 wasn't used. We'd need an extra param to implement that. That would also make the logic to decide when to use EIP155 would be more complex, and it's already fairly complex. IMO it's better to use EIP155 by default, giving the users replay-protection by default. This EIP has been active for a long time now.

(8) ~~Maybe this should be done in the `v` setter. What do you think? It would require a call to `Object.defineProperty` in the constructor, as anything in the prototype is shadowed by `defineProperties`.~~ Update: See next comment