### PR TITLE
Expose FakeTransaction named as FakeTransaction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { default as Transaction } from './transaction'
-export { default as Fake } from './fake'
+export { default as FakeTransaction } from './fake'
 export * from './types'

--- a/test/fake.ts
+++ b/test/fake.ts
@@ -2,7 +2,7 @@ import * as tape from 'tape'
 import { Buffer } from 'buffer'
 import { bufferToHex } from 'ethereumjs-util'
 import Common from 'ethereumjs-common'
-import FakeTransaction from '../src/fake'
+import { FakeTransaction } from '../src'
 import { FakeTxData } from './types'
 
 // Use private key 0x0000000000000000000000000000000000000000000000000000000000000001 as 'from' Account


### PR DESCRIPTION
I think `FakeTransaction` in `index.ts` should be completely exposed as `FakeTransaction` and not just a shortened `Fake`. This name is not descriptive enough - this could point to various things - and especially in the context of tx instantiation we should be rather more precise. This is also confusing when looking at the [documentation](https://github.com/ethereumjs/ethereumjs-tx/blob/master/docs/README.md) and seeing the fully written class name.

I thought twice about renaming the file names in `src` and `test` as well but then concluded this to be unnecessary and decided against. Can nevertheless update this as well if considered to be more consistent.