### PR TITLE
Add support for EIP-2028 for Istanbul

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "mjbecze <mb@ethdev.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "ethereumjs-common": "^1.3.0",
+    "ethereumjs-common": "^1.3.1",
     "ethereumjs-util": "^6.0.0"
   },
   "devDependencies": {

--- a/test/api.ts
+++ b/test/api.ts
@@ -410,4 +410,14 @@ tape('[Transaction]: Basic functions', function(t) {
       st.end()
     },
   )
+
+  t.test('should return correct data fee for istanbul', function(st) {
+    let tx = new Transaction({}, { hardfork: 'istanbul' })
+    st.equals(tx.getDataFee().toNumber(), 0)
+
+    tx = new Transaction(txFixtures[3].raw, { hardfork: 'istanbul' })
+    st.equals(tx.getDataFee().toNumber(), 1716)
+
+    st.end()
+  })
 })


### PR DESCRIPTION
EIP-2028 reduces non-zero call data gas prices which made it into ethereumjs-common v1.3.1 release (https://github.com/ethereumjs/ethereumjs-common/pull/58). This PR updates Common and adds a simple test case.