### PR TITLE
fix test runner

### DIFF
--- a/test/transactionRunner.ts
+++ b/test/transactionRunner.ts
@@ -36,14 +36,12 @@ tape('TransactionTests', t => {
       'TransactionTests',
       (_filename: string, testName: string, testData: OfficialTransactionTestData) => {
         t.test(testName, st => {
-          const rawTx = toBuffer(testData.rlp)
-
-          let tx
           forkNames.forEach(forkName => {
             const forkTestData = testData[forkName]
             const shouldBeInvalid = Object.keys(forkTestData).length === 0
             try {
-              tx = new Tx(rawTx, {
+              const rawTx = toBuffer(testData.rlp)
+              const tx = new Tx(rawTx, {
                 hardfork: forkNameMap[forkName],
                 chain: 1,
               })


### PR DESCRIPTION
Tests are currently broken here:

```
# RLPWrongAddress

(node:22784) UnhandledPromiseRejectionWarning: Error: Cannot convert string to buffer. toBuffer only supports 0x-prefixed hex strings and this string was given: 0xf85f800182094894095v7baea6a6c7c4c2dfeb977efac326af552d870a801ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804
```
The data is purposefully malformed, so I put the `const rawTx = toBuffer(testData.rlp)` in the try catch block so the error would catch properly.