### PR TITLE
New release v2.1.2, updated Common dependency (MuirGlacier)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2019-12-19
+
+- Added support for the `MuirGlacier` HF by updating the `ethereumjs-common` dependency
+  to [v1.5.0](https://github.com/ethereumjs/ethereumjs-common/releases/tag/v1.5.0)
+
+[2.1.2]: https://github.com/ethereumjs/ethereumjs-tx/compare/v2.1.1...v2.1.2
+
 ## [2.1.1] - 2019-08-30
 
 - Added support for `Istanbul` reduced non-zero call data gas prices

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ using an object with `chain` and `hardfork` names. You can see en example of thi
 
 The second option is by passing the option `common` set to an instance of [ethereumjs-common](https://github.com/ethereumjs/ethereumjs-common)' Common. This is specially useful for custom networks or chains/hardforks not yet supported by `ethereumjs-common`. You can see en example of this in [./examples/custom-chain-tx.ts](./examples/custom-chain-tx.ts).
 
+## MuirGlacier Support
+
+The `MuirGlacier` hardfork is supported by the library since the `v2.1.2` release.
+
 ## Istanbul Support
 
 Support for reduced non-zero call data gas prices from the `Istanbul` hardfork

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "mjbecze <mb@ethdev.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "ethereumjs-common": "^1.3.1",
+    "ethereumjs-common": "^1.5.0",
     "ethereumjs-util": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-tx",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A simple module for creating, manipulating and signing Ethereum transactions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
@evertonfraga I think we should actually make this complete and also update the tx library. Code is not touched here, but cases like this lead to inconsistencies in the past, if e.g. the Common instance from the tx library is used and passed on along the VM and this would be still an old version without MuirGlacier support.