### PR TITLE
Changes EIP links to preferred citation format

### DIFF
--- a/test/api.ts
+++ b/test/api.ts
@@ -217,7 +217,7 @@ tape('[Transaction]: Basic functions', function(t) {
   })
 
   t.test('Verify EIP155 Signature before and after signing with private key', function(st) {
-    // Inputs and expected results for this test are taken directly from the example in https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
+    // Inputs and expected results for this test are taken directly from the example in https://eips.ethereum.org/EIPS/eip-155
     const txRaw = [
       '0x09',
       '0x4a817c800',


### PR DESCRIPTION
While updating the links across the 6 repos for the migration, I bumped into these different formats for EIP links. As they does not impact the migration, I decided to update them now.

> **Preferred Citation Format [1]**
> The canonical URL for a EIP that has achieved draft status at any point is at https://eips.ethereum.org/. For example, the canonical URL for EIP-1 is https://eips.ethereum.org/EIPS/eip-1.

[Reference](https://github.com/ethereum/EIPs/blob/af677b348da866d41a58d8948a89d0b00d410e2b/README.md#preferred-citation-format).