### PR TITLE
Set default fork to Istanbul instead of Petersburg

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -80,7 +80,7 @@ export default class Transaction {
       this._common = opts.common
     } else {
       const chain = opts.chain ? opts.chain : 'mainnet'
-      const hardfork = opts.hardfork ? opts.hardfork : 'petersburg'
+      const hardfork = opts.hardfork ? opts.hardfork : 'istanbul'
 
       this._common = new Common(chain, hardfork)
     }


### PR DESCRIPTION
I've been receiving the error `gas limit is too low. Need at least`. This is likely due to the decreased gas price for calldata in Istanbul.

The Istanbul data is already available in ethereumjs-common, this PR just uses Istanbul by default.